### PR TITLE
Add awaits, improve async programming in general

### DIFF
--- a/src/components/anti-autoreact.ts
+++ b/src/components/anti-autoreact.ts
@@ -31,9 +31,8 @@ export class AntiAutoreact extends BotComponent {
             const message = await departialize(reaction.message);
             if(obnoxious_autoreact_immunity.has(message.author.id)) {
                 M.debug("Auto-react being removed");
-                for(const [ id, _ ] of reaction.users.cache) {
-                    reaction.users.remove(id);
-                }
+
+                await Promise.all(reaction.users.cache.map(user => reaction.users.remove(user)));
             }
         }
     }

--- a/src/components/buzzwords.ts
+++ b/src/components/buzzwords.ts
@@ -207,14 +207,14 @@ export class Buzzwords extends BotComponent {
 
     override async on_ready() {
         if(ENABLED) { // eslint-disable-line @typescript-eslint/no-unnecessary-condition
-            this.update_database();
+            const promises = Promise.all([ this.update_database(), this.reflowRoles() ]);
             this.timeout = setTimeout(() => {
                 this.update_database();
             }, MINUTE);
-            this.reflowRoles();
             this.interval = setInterval(() => {
                 this.reflowRoles();
             }, 10 * MINUTE);
+            await promises;
         }
     }
 
@@ -373,7 +373,7 @@ export class Buzzwords extends BotComponent {
                     this.set_points(id, tag, parseInt(amount));
                     if(member instanceof Discord.GuildMember) await this.updateRolesSingle(member);
                     await message.reply("Done");
-                    this.update_database();
+                    await this.update_database();
                 } else {
                     await message.reply({
                         embeds: [

--- a/src/components/format.ts
+++ b/src/components/format.ts
@@ -279,7 +279,7 @@ export class Format extends BotComponent {
         } catch(e) {
             critical_error(e);
             try {
-                message.reply("Internal error while running !f");
+                await message.reply("Internal error while running !f");
             } catch(e) {
                 critical_error(e);
             }

--- a/src/components/forum-channels.ts
+++ b/src/components/forum-channels.ts
@@ -107,7 +107,7 @@ export class ForumChannels extends BotComponent {
         // thread.lastMessageId can be null if there are no messages (possibly and the forum starter has been deleted)
         // if the thread author hasn't sent an initial message it'll mess things up, this needs manual review
         if(thread.lastMessageId == null) {
-            this.wheatley.zelis.send(`thread.lastMessageId is null for ${thread.url}`);
+            await this.wheatley.zelis.send(`thread.lastMessageId is null for ${thread.url}`);
             return;
         }
         const now = Date.now();

--- a/src/components/massban.ts
+++ b/src/components/massban.ts
@@ -25,7 +25,7 @@ export class Massban extends BotComponent {
             if(message.content.startsWith("!wban")) {
                 assert(message.member != null);
                 if(is_authorized_admin(message.member)) {
-                    this.do_mass_ban(message);
+                    await this.do_mass_ban(message);
                 } else {
                     await message.reply(`Unauthorized ${pepereally}`);
                 }
@@ -35,7 +35,7 @@ export class Massban extends BotComponent {
         }
     }
 
-    do_mass_ban(msg: Discord.Message) {
+    async do_mass_ban(msg: Discord.Message) {
         // TODO: Do DM logic?
         // TODO: Set entry.purged if necessary?
         M.log("Got massban command");
@@ -48,14 +48,15 @@ export class Massban extends BotComponent {
             for(const id of ids) {
                 msg.guild.members.ban(id, { reason: "[[Wheatley]] Manual mass-ban" });
             }
-            msg.reply("Done.");
+            const replyPromise = msg.reply("Done.");
             // TODO: use long-message logic?
             const embed = new Discord.EmbedBuilder()
                 .setColor(colors.color)
                 .setTitle(`<@!${msg.author.id}> banned ${ids.length} users`)
                 .setDescription(`\`\`\`\n${ids.join("\n")}\n\`\`\``)
                 .setTimestamp();
-            this.wheatley.action_log_channel.send({ embeds: [embed] });
+            await this.wheatley.action_log_channel.send({ embeds: [embed] });
+            await replyPromise;
         }
     }
 }

--- a/src/components/modmail.ts
+++ b/src/components/modmail.ts
@@ -21,11 +21,10 @@ import { Wheatley } from "../wheatley.js";
 const RATELIMIT_TIME = 5 * MINUTE;
 
 function create_embed(title: string, msg: string) {
-    const embed = new Discord.EmbedBuilder()
+    return new Discord.EmbedBuilder()
         .setColor(colors.color)
         .setTitle(title)
         .setDescription(msg);
-    return embed;
 }
 
 type database_schema = number;
@@ -60,7 +59,7 @@ export class Modmail extends BotComponent {
                 const member = await this.wheatley.TCCPP.members.fetch(interaction.member.user.id);
                 // make the thread
                 const id = this.modmail_id_counter++;
-                this.update_db();
+                const updateDbPromise = this.update_db();
                 const thread =  await this.wheatley.rules_channel.threads.create({
                     type: Discord.ChannelType.PrivateThread,
                     invitable: false,
@@ -94,6 +93,7 @@ export class Modmail extends BotComponent {
                         roles: [moderators_role_id]
                     }
                 });
+                await updateDbPromise;
             } catch(e) {
                 await interaction.update({
                     content: "Something went wrong internally...",

--- a/src/components/quote.ts
+++ b/src/components/quote.ts
@@ -273,7 +273,7 @@ export class Quote extends BotComponent {
                             .setColor(colors.red)
                             .setDescription("Error: You don't have permissions for that channel")
                     );
-                    this.wheatley.zelis.send("quote exploit attempt");
+                    await this.wheatley.zelis.send("quote exploit attempt");
                     continue;
                 }
                 let messages: Discord.Message[] = [];

--- a/src/components/roulette.ts
+++ b/src/components/roulette.ts
@@ -141,9 +141,11 @@ export class Roulette extends BotComponent {
                 await this.update_scoreboard(command.user.id);
             }
         } else {
-            command.reply("Warning: This is __Russian Roulette__. Losing will result in a 30 minute timeout."
-                        + " Proceed at your own risk.");
+            const msg = "Warning: This is __Russian Roulette__. Losing will result in a 30 minute timeout."
+                + " Proceed at your own risk.";
+            const replyPromise = command.reply(msg);
             this.warned_users.insert(command.user.id);
+            await replyPromise;
         }
     }
 

--- a/src/components/server-suggestion-tracker.ts
+++ b/src/components/server-suggestion-tracker.ts
@@ -249,8 +249,11 @@ export class ServerSuggestionTracker extends BotComponent {
                 maybe: 0
             };
             const updateDbPromise = this.wheatley.database.update();
-            // add react options
-            await Promise.all(resolution_reactions.map(reaction => status_message.react(reaction)));
+            for(const r of resolution_reactions) {
+                // This code is intentionally synchronous so that the suggested
+                // actions always appear in the same order.
+                await status_message.react(r);
+            }
             await updateDbPromise;
         } catch(e) {
             critical_error("error during open_suggestion", e);

--- a/src/components/speedrun.ts
+++ b/src/components/speedrun.ts
@@ -17,7 +17,7 @@ export class Speedrun extends BotComponent {
         this.wheatley.tracker.add_submodule({ on_ban: this.on_ban.bind(this) });
     }
 
-    on_ban(ban: Discord.GuildBan, now: number) {
+    async on_ban(ban: Discord.GuildBan, now: number) {
         M.debug("speedrun check");
         const user = ban.user;
         // get user info
@@ -53,6 +53,6 @@ export class Speedrun extends BotComponent {
                 text: `ID: ${user.id}`
             })
             .setTimestamp();
-        this.wheatley.action_log_channel.send({ embeds: [embed] });
+        await this.wheatley.action_log_channel.send({ embeds: [embed] });
     }
 }

--- a/src/components/starboard.ts
+++ b/src/components/starboard.ts
@@ -181,7 +181,7 @@ export class Starboard extends BotComponent {
     }
 
     async update_starboard(message: Discord.Message) {
-        this.mutex.lock(message.id);
+        await this.mutex.lock(message.id);
         try {
             const make_embeds = () => make_quote_embeds(
                 [message],
@@ -246,7 +246,7 @@ export class Starboard extends BotComponent {
             await this.wheatley.staff_flag_log.send({
                 content: `${action} message from <@${message.author.id}> for `
                     + `${delete_reaction.count} ${delete_reaction.emoji.name} reactions`
-                    + `\n${await this.reactions_string(message)}`
+                    + `\n${this.reactions_string(message)}`
                     + "\n" + (await delete_reaction.users.fetch()).map(user => `<@${user.id}> ${user.tag}`).join("\n"),
                 ...await make_quote_embeds(
                     [message],
@@ -325,7 +325,7 @@ export class Starboard extends BotComponent {
 
     override async on_message_delete(message: Discord.Message<boolean> | Discord.PartialMessage) {
         if(message.id in this.data.starboard) {
-            this.mutex.lock(message.id);
+            await this.mutex.lock(message.id);
             try {
                 await this.wheatley.starboard_channel.messages.delete(this.data.starboard[message.id]);
                 delete this.data.starboard[message.id];

--- a/src/components/the-button.ts
+++ b/src/components/the-button.ts
@@ -256,7 +256,7 @@ export class TheButton extends BotComponent {
             if(scoreboard[interaction.user.id].tag == "") {
                 scoreboard[interaction.user.id].tag = interaction.user.tag;
             }
-            this.update_message();
+            const updateMsgPromise = this.update_message();
             const time_since_reset = DAY - delta;
             const points = F(time_since_reset / DAY) * DAY / 1000 / 60;
             scoreboard[interaction.user.id].score += points;
@@ -277,6 +277,7 @@ export class TheButton extends BotComponent {
                 ephemeral: true
             });
             await this.update_database();
+            await updateMsgPromise;
         }
         if(interaction.isButton() && interaction.customId == "the-button-scoreboard") {
             const scores = this.get_scoreboard_entries().slice(0, 15);

--- a/src/components/thread-control.ts
+++ b/src/components/thread-control.ts
@@ -98,8 +98,9 @@ export class ThreadControl extends BotComponent {
                 return;
             }
             await thread.setName(name);
+            let replyPromise;
             if(command.is_slash()) {
-                command.reply("✅", true);
+                replyPromise = command.reply("✅", true);
             } else {
                 await command.delete_invocation();
             }
@@ -112,6 +113,9 @@ export class ThreadControl extends BotComponent {
                 if(message.type == Discord.MessageType.Default && message.author.id == this.wheatley.id) {
                     message.delete();
                 }
+            }
+            if (replyPromise) {
+                await replyPromise;
             }
         }
     }


### PR DESCRIPTION
In its current state, Wheatley contains a lot of minor or major issues related to async programming. A large amount of Discord message sending or replying is missing `await`s, so if any of it fails, it will turn into unhandled promise rejections. This isn't the end of the world, but it's also not good practice and makes it a critical error when it shouldn't be.

Furthermore, there is plenty of code which uses `await` excessively. This PR doesn't fix anywhere near all such cases, but does create promise variables in some cases, so that the code isn't effectively synchronous.

The PR also fixes some misuses of mutexes:
```diff
-this.mutex.lock(message.id);
+await this.mutex.lock(message.id);
```
Such changes are applied in one or two places.