### PR TITLE
Fix and improve `std::endl` article

### DIFF
--- a/wiki_articles/endl.md
+++ b/wiki_articles/endl.md
@@ -1,28 +1,35 @@
 # About `std::endl`, Buffers, And Flushing
 
-I/O in C++ (`std::cout`, i.e.`std::ostream`) is *buffered*,
-which means that not every byte you write to the stream is instantly written through to the terminal/disk.
+I/O in C++
+(**[std::cout](https://en.cppreference.com/w/cpp/io/cout)**, i.e.
+**[std::ostream](https://en.cppreference.com/w/cpp/io/basic_ostream)**)
+is *buffered*, which means that not every byte you write to the stream is
+instantly written through to the terminal/disk.
 Doing so would be very slow.
 
 Instead, there is a buffer of e.g. 8192 bytes and when it's full,
-all data is written through to the OS (flushed) in one syscall.
+all data is written through to the OS, i.e. *flushed* in one syscall.
 This is much more efficient.
 
 <!-- inline -->
 ## What is *flushing*?
-*Flushing* means that all bytes currently in the buffer are written through, and the buffer is cleared.
+*Flushing* means that all bytes currently in the buffer are written through,
+and the buffer is cleared.
 
-Use `<< std::flush` to flush, or use `std::cerr`, which is unbuffered.
+Use **[<< std::flush](https://en.cppreference.com/w/cpp/io/manip/flush)**
+or **[.flush()](https://en.cppreference.com/w/cpp/io/basic_ostream/flush)**
+to flush, or use
+**[std::cerr](https://en.cppreference.com/w/cpp/io/cerr)**, which is unbuffered.
 
 <!-- inline -->
 ## `std::endl`
-This [I/O manipulator](https://en.cppreference.com/w/cpp/io/manip) writes a newline character to the stream,
-but also flushes it.
+**[std::endl](https://en.cppreference.com/w/cpp/io/manip/endl)**
+is an
+[I/O manipulator](https://en.cppreference.com/w/cpp/io/manip) which writes a
+newline character to the stream, and flushes it.
 
-Use `<< '\n'` instead, if you don't need to flush.
+Use `<< '\n'` if you don't need to flush.
 
 ## See Also
-<:stackoverflow:874353689031233606>
-["std::endl" vs "\n"](https://stackoverflow.com/q/213907/5740428)<br>
-- **[std::endl](https://en.cppreference.com/w/cpp/io/manip/endl)**
-- **[std::flush](https://en.cppreference.com/w/cpp/io/manip/flush)**
+<:stackoverflow:1074747016644661258>
+["std::endl" vs "\n"](https://stackoverflow.com/q/213907/5740428)

--- a/wiki_articles/endl.md
+++ b/wiki_articles/endl.md
@@ -3,8 +3,8 @@
 I/O in C++
 (**[std::cout](https://en.cppreference.com/w/cpp/io/cout)**, i.e.
 **[std::ostream](https://en.cppreference.com/w/cpp/io/basic_ostream)**)
-is *buffered*, which means that not every byte you write to the stream is
-instantly written through to the terminal/disk.
+is *buffered*, which means that not every character you write to the stream
+is instantly written through to the terminal/disk.
 Doing so would be very slow.
 
 Instead, there is a buffer of e.g. 8192 bytes and when it's full,


### PR DESCRIPTION
![grafik](https://github.com/jeremy-rifkin/wheatley-mirror/assets/22040976/c386c3d1-0681-45ae-8f75-f925bb3885fd)

The current version has a broken SO emote, and could be enriched with a number of links in the text. This also allows shortening the *See Also* section.

I'm also making a few grammatical improvements, because I wasn't as good at English back when I wrote the original, and have made some mistakes.